### PR TITLE
Fix failure to compile with heated bed:

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1452,8 +1452,7 @@ void process_commands()
         if(code_seen('P')) bedKp = code_value();
         if(code_seen('I')) bedKi = scalePID_i(code_value());
         if(code_seen('D')) bedKd = scalePID_d(code_value());
-        // Scale the Bed PID values by PID_dT
-        scaleBedPID();
+
         updatePID();
         SERIAL_PROTOCOL(MSG_OK);
 		SERIAL_PROTOCOL(" p:");


### PR DESCRIPTION
Remove call to non-existant scaleBedPID() function. Have confirmed it does now compile properly with PIDTEMPBED enabled.
