### PR TITLE
Fix acceleration limits, when axes have differing requirements.

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -37,7 +37,7 @@
 # from the commandline with "make HARDWARE_MOTHERBOARD=71" for example
 
 # This defined the board you are compiling for (see Configuration.h for the options)
-HARDWARE_MOTHERBOARD ?= 11
+HARDWARE_MOTHERBOARD ?= 7
 
 # Arduino source install directory, and version number
 ARDUINO_INSTALL_DIR  ?= ../../arduino-0022

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -620,7 +620,8 @@ void plan_buffer_line(const float &x, const float &y, const float &z, const floa
   }
   float inverse_millimeters = 1.0/block->millimeters;  // Inverse millimeters to remove multiple divides 
 
-    // Calculate speed in mm/second for each axis. No divide by zero due to previous checks.
+
+  // calculate moves/second for this move. No divide by zero due to previous checks.
   float inverse_second = feed_rate * inverse_millimeters;
 
   int moves_queued=(block_buffer_head-block_buffer_tail + BLOCK_BUFFER_SIZE) & (BLOCK_BUFFER_SIZE - 1);
@@ -718,15 +719,24 @@ void plan_buffer_line(const float &x, const float &y, const float &z, const floa
     block->acceleration_st = ceil(acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
     // Limit acceleration per axis
     if(((float)block->acceleration_st * (float)block->steps_x / (float)block->step_event_count) > axis_steps_per_sqr_second[X_AXIS])
-      block->acceleration_st = axis_steps_per_sqr_second[X_AXIS];
+    	// acceleration is too fast for x, so limit acceleration to a rate that just passes the test on previous line
+    	block->acceleration_st = axis_steps_per_sqr_second[X_AXIS] * (float)block->step_event_count/(float)block->steps_x;
+
     if(((float)block->acceleration_st * (float)block->steps_y / (float)block->step_event_count) > axis_steps_per_sqr_second[Y_AXIS])
-      block->acceleration_st = axis_steps_per_sqr_second[Y_AXIS];
+    	// acceleration is too fast for y, so limit acceleration to a rate that just passes the test on previous line
+    	block->acceleration_st = axis_steps_per_sqr_second[Y_AXIS] * (float)block->step_event_count/(float)block->steps_y;
+
     if(((float)block->acceleration_st * (float)block->steps_e / (float)block->step_event_count) > axis_steps_per_sqr_second[E_AXIS])
-      block->acceleration_st = axis_steps_per_sqr_second[E_AXIS];
+    	// acceleration is too fast for e, so limit acceleration to a rate that just passes the test on previous line
+    	block->acceleration_st = axis_steps_per_sqr_second[E_AXIS] * (float)block->step_event_count/(float)block->steps_e;
+
     if(((float)block->acceleration_st * (float)block->steps_z / (float)block->step_event_count ) > axis_steps_per_sqr_second[Z_AXIS])
-      block->acceleration_st = axis_steps_per_sqr_second[Z_AXIS];
+    	// acceleration is too fast for z, so limit acceleration to a rate that just passes the test on previous line
+    	block->acceleration_st = axis_steps_per_sqr_second[Z_AXIS] * (float)block->step_event_count/(float)block->steps_z;
   }
   block->acceleration = block->acceleration_st / steps_per_mm;
+
+  // TODO: What is the significance of 8.388608? Should it be defined as a constant, or static somewhere? Could it ever change?
   block->acceleration_rate = (long)((float)block->acceleration_st * 8.388608);
 
 #if 0  // Use old jerk for now


### PR DESCRIPTION
When moving in x, y and z all at the same time, the planner tries to blend the accelerations so no axis exceeds its max acceleration; it does this taking into account the proportional number of steps used on each axis... however, when it finds the limit has been exceeded, it simply uses the raw acceleration value, not the proportional value used in the test. 

This same logic also needs fixing in the UM2 firmware - looks like its around like 780 in planner.cpp
