### PR TITLE
Fix for M117 missing character when printing via USB

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2181,7 +2181,7 @@ void process_commands()
     case 117: // M117 display message
       starpos = (strchr(strchr_pointer + 5,'*'));
       if(starpos!=NULL)
-        *(starpos-1)='\0';
+        *starpos='\0';
       lcd_setstatus(strchr_pointer + 5);
       break;
     case 114: // M114


### PR DESCRIPTION
When M117 has a checksum, the string termination is set on the last character instead of the '*' character. As result we loose one character on the display.
